### PR TITLE
findDOMNode function is defined by ReactDOM

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ var ContentEditable = createClass({
     e.preventDefault();
     var data = e.clipboardData.getData('text/plain')
     this._replaceCurrentSelection(data);
-    var target = React.findDOMNode(this)
+    var target = ReactDOM.findDOMNode(this)
     this.props.onChange(target.textContent, false, target)
   },
 


### PR DESCRIPTION
Dear @ygravrand 

Please find this pull request as a fix for a bug when pasting text.

A later commit has left an occurrence of `React.findDOMNode` while they had been replaced with `ReactDOM.findDOMNode` by another commit.

Best regards